### PR TITLE
Performance improvements

### DIFF
--- a/src/main/java/nex/handler/EventHandler.java
+++ b/src/main/java/nex/handler/EventHandler.java
@@ -380,50 +380,29 @@ public class EventHandler
         BlockPos pos = new BlockPos(event.getEntityLiving());
         EntityLivingBase entity = event.getEntityLiving();
 
-        boolean canEntityFreeze = EntityUtil.canFreeze(entity);
+        boolean canEntityFreeze = entity instanceof EntityPlayer || EntityUtil.canFreeze(entity);
 
-        if(world.getBiome(pos) == NetherExBiomes.ARCTIC_ABYSS)
+        if(canEntityFreeze)
         {
-            if(canEntityFreeze && !EntityUtil.isFrozen(entity) && world.rand.nextInt(ConfigHandler.biome.arcticAbyss.chanceOfFreezing) == 0)
+            boolean entityFrozen = EntityUtil.isFrozen(entity);
+            if(!entityFrozen && world.rand.nextInt(ConfigHandler.biome.arcticAbyss.chanceOfFreezing) == 0 && world.getBiome(pos) == NetherExBiomes.ARCTIC_ABYSS)
             {
                 entity.addPotionEffect(new PotionEffect(NetherExEffects.FREEZE, 300, 0));
             }
-        }
-        if(canEntityFreeze || entity instanceof EntityPlayer)
-        {
-            if(EntityUtil.isFrozen(entity))
+
+            if(entityFrozen)
             {
-                if(entity instanceof EntityLiving)
-                {
-                    ((EntityLiving) entity).setNoAI(true);
-                }
-
-                entity.setSilent(true);
-
                 if(entity instanceof EntityPlayer)
                 {
                     entity.setPosition(entity.prevPosX, entity.posY, entity.prevPosZ);
                 }
-
                 if(world.rand.nextInt(ConfigHandler.potionEffect.freeze.chanceOfThawing) == 0)
                 {
                     entity.removePotionEffect(NetherExEffects.FREEZE);
                 }
             }
-            else
-            {
-                if(entity instanceof EntityLiving)
-                {
-                    if(((EntityLiving) entity).isAIDisabled())
-                    {
-                        ((EntityLiving) entity).setNoAI(false);
-                    }
-                }
-
-                entity.setSilent(false);
-            }
         }
-        if(EntityUtil.canSpreadSpores(entity) && EntityUtil.isSporeInfested(entity) && world.rand.nextInt(ConfigHandler.potionEffect.spore.chanceOfSporeSpawning) == 0)
+        if(EntityUtil.isSporeInfested(entity) && EntityUtil.canSpreadSpores(entity) && world.rand.nextInt(ConfigHandler.potionEffect.spore.chanceOfSporeSpawning) == 0)
         {
             if(world.getEntitiesWithinAABB(EntityLivingBase.class, new AxisAlignedBB(pos).expand(1, 1, 1)).size() < 3)
             {
@@ -437,7 +416,7 @@ public class EventHandler
                 }
             }
         }
-        if(EntityUtil.canSpawnGhastling(entity) && EntityUtil.isLostAfflicted(entity) && world.rand.nextInt(ConfigHandler.potionEffect.lost.chanceOfGhastlingSpawning) == 0)
+        if(EntityUtil.isLostAfflicted(entity) && EntityUtil.canSpawnGhastling(entity) && world.rand.nextInt(ConfigHandler.potionEffect.lost.chanceOfGhastlingSpawning) == 0)
         {
             BlockPos newPos = pos.add(0, 5, 0).offset(entity.getHorizontalFacing().getOpposite(), 5);
 

--- a/src/main/java/nex/handler/EventHandler.java
+++ b/src/main/java/nex/handler/EventHandler.java
@@ -81,23 +81,13 @@ import java.util.Random;
 @Mod.EventBusSubscriber(modid = NetherEx.MOD_ID)
 public class EventHandler
 {
-    @SubscribeEvent
-    public static void onWorldLoad(WorldEvent.Load event)
-    {
-        World world = event.getWorld();
-
-        if(!world.isRemote)
-        {
-            PigtificateVillageManager.init(world);
-        }
-    }
 
     @SubscribeEvent
     public static void onWorldTick(TickEvent.WorldTickEvent event)
     {
         if(event.phase == TickEvent.Phase.START)
         {
-            PigtificateVillageCollection villages = PigtificateVillageManager.getPigtificateVillages(event.world);
+            PigtificateVillageCollection villages = PigtificateVillageManager.getPigtificateVillagesNoCreate(event.world);
 
             if(villages != null)
             {

--- a/src/main/java/nex/init/NetherExEffects.java
+++ b/src/main/java/nex/init/NetherExEffects.java
@@ -17,6 +17,9 @@
 
 package nex.init;
 
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.ai.attributes.AbstractAttributeMap;
 import net.minecraft.potion.Potion;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -30,7 +33,32 @@ import org.apache.logging.log4j.Logger;
 @GameRegistry.ObjectHolder(NetherEx.MOD_ID)
 public class NetherExEffects
 {
-    public static final PotionNetherEx FREEZE = new PotionNetherEx("freeze", true, 93, 188, 210);
+    public static final PotionNetherEx FREEZE = new PotionNetherEx("freeze", true, 93, 188, 210){
+        @Override
+        public void applyAttributesModifiersToEntity(EntityLivingBase entity, AbstractAttributeMap attributeMapIn, int amplifier) {
+            super.applyAttributesModifiersToEntity(entity, attributeMapIn, amplifier);
+            if(entity instanceof EntityLiving)
+            {
+                ((EntityLiving) entity).setNoAI(true);
+            }
+
+            entity.setSilent(true);
+        }
+
+        @Override
+        public void removeAttributesModifiersFromEntity(EntityLivingBase entity, AbstractAttributeMap attributeMapIn, int amplifier) {
+            super.removeAttributesModifiersFromEntity(entity, attributeMapIn, amplifier);
+            if(entity instanceof EntityLiving)
+            {
+                if(((EntityLiving) entity).isAIDisabled())
+                {
+                    ((EntityLiving) entity).setNoAI(false);
+                }
+            }
+
+            entity.setSilent(false);
+        }
+    };
     public static final PotionNetherEx FROSTBITE = new PotionNetherEx("frostbite", true, 19, 226, 255);
     public static final PotionNetherEx SPORE = new PotionNetherEx("spore", true, 142, 96, 40);
     public static final PotionNetherEx LOST = new PotionNetherEx("lost", true, 103, 62, 124);

--- a/src/main/java/nex/util/EntityUtil.java
+++ b/src/main/java/nex/util/EntityUtil.java
@@ -25,25 +25,56 @@ import net.minecraft.world.DimensionType;
 import nex.handler.ConfigHandler;
 import nex.init.NetherExEffects;
 
-import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 public class EntityUtil
 {
+    private static Map<Class<? extends EntityLivingBase>, String> RESOURCE_LOCATION_CACHE = new HashMap<>();
+    //cached version of EntityList.getKey
+    private static String getEntityLocation(EntityLivingBase entity)
+    {
+        Class<? extends EntityLivingBase> clazz = entity.getClass();
+        return RESOURCE_LOCATION_CACHE.computeIfAbsent(clazz, k->{
+            ResourceLocation loc = EntityList.getKey(k);
+            return loc != null ? loc.toString() : null;
+        });
+    }
+
+    private static boolean contains(String[] haystack, String needle)
+    {
+        if (needle == null) {
+            for (String hay : haystack)
+                if (hay == null)
+                    return true;
+        } else {
+            for (String hay : haystack)
+                if (needle.equals(hay))
+                    return true;
+        }
+        return false;
+    }
+
     public static boolean canFreeze(EntityLivingBase entity)
     {
-        ResourceLocation entityRegistryName = EntityList.getKey(entity);
-        return !(entity instanceof EntityPlayer) && entityRegistryName != null && !Arrays.asList(ConfigHandler.potionEffect.freeze.blacklist).contains(entityRegistryName.toString());
+        if (entity instanceof EntityPlayer){
+            return false;
+        }
+        String entityRegistryName = getEntityLocation(entity);
+        return entityRegistryName != null && !contains(ConfigHandler.potionEffect.freeze.blacklist, entityRegistryName);
     }
 
     public static boolean canSpreadSpores(EntityLivingBase entity)
     {
-        ResourceLocation entityRegistryName = EntityList.getKey(entity);
-        return entity instanceof EntityPlayer || (entityRegistryName != null && !Arrays.asList(ConfigHandler.potionEffect.spore.blacklist).contains(entityRegistryName.toString()));
+        if (entity instanceof EntityPlayer)
+            return true;
+        String entityRegistryName = getEntityLocation(entity);
+        return (entityRegistryName != null && !contains(ConfigHandler.potionEffect.spore.blacklist, entityRegistryName));
     }
 
     public static boolean canSpawnGhastling(EntityLivingBase entity)
     {
-        return entity instanceof EntityPlayer && entity.getEntityWorld().provider.getDimension() == DimensionType.NETHER.getId();
+        return entity instanceof EntityPlayer && entity.getEntityWorld().provider.getDimensionType() == DimensionType.NETHER;
     }
 
     public static boolean isFrozen(EntityLivingBase entity)

--- a/src/main/java/nex/village/PigtificateVillageCollection.java
+++ b/src/main/java/nex/village/PigtificateVillageCollection.java
@@ -54,6 +54,9 @@ public class PigtificateVillageCollection extends WorldSavedData
 
     public void setWorldsForAll(World worldIn)
     {
+        if (world == worldIn){
+            return;
+        }
         world = worldIn;
 
         for(PigtificateVillage village : villageList)

--- a/src/main/java/nex/village/PigtificateVillageManager.java
+++ b/src/main/java/nex/village/PigtificateVillageManager.java
@@ -17,20 +17,15 @@
 
 package nex.village;
 
-import com.google.common.collect.Maps;
 import net.minecraft.world.World;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Map;
-
 public class PigtificateVillageManager
 {
-    private static final Map<World, PigtificateVillageCollection> pigtificateVillages = Maps.newHashMap();
-
     private static final Logger LOGGER = LogManager.getLogger("NetherEx|PigtificateVillageManager");
 
-    public static void init(World world)
+    private static PigtificateVillageCollection getOrCreate(World world)
     {
         String dimension = world.provider.getDimensionType().name().toLowerCase();
         String id = PigtificateVillageCollection.fileNameForProvider(world.provider);
@@ -40,20 +35,23 @@ public class PigtificateVillageManager
         {
             LOGGER.info("The Pigtificate Village data for " + dimension + " was created successfully.");
 
-            pigtificateVillages.put(world, new PigtificateVillageCollection(world));
-            world.getPerWorldStorage().setData(id, pigtificateVillages.get(world));
+            pigtificateVillageCollection = new PigtificateVillageCollection(world);
+            world.getPerWorldStorage().setData(id, pigtificateVillageCollection);
         }
         else
         {
-            LOGGER.info("The Pigtificate Village data for " + dimension + " was read successfully.");
-
-            pigtificateVillages.put(world, pigtificateVillageCollection);
-            pigtificateVillages.get(world).setWorldsForAll(world);
+            pigtificateVillageCollection.setWorldsForAll(world);
         }
+        return pigtificateVillageCollection;
     }
 
     public static PigtificateVillageCollection getPigtificateVillages(World world)
     {
-        return pigtificateVillages.get(world);
+        return getOrCreate(world);
+    }
+
+    public static PigtificateVillageCollection getPigtificateVillagesNoCreate(World world){
+        String id = PigtificateVillageCollection.fileNameForProvider(world.provider);
+        return (PigtificateVillageCollection) world.getPerWorldStorage().getOrLoadData(PigtificateVillageCollection.class, id);
     }
 }


### PR DESCRIPTION
While investigating some performance issue on my Sevtech server, your mod came up in profiling a fair bit. These modifications have reduced this impact to barely anything.

- PigtificateVillageManager was leaking worlds! 
    - Storing a `World` object in a map prevents the world object from being GCed, as you didn't have any unload handling. 
    - It is also not necessary to cache the saved data, as it is already in a map inside the World object.
    - I also made it lazy load, so that if nothing ever writes to it, it wont be saved/ticked at all
- LivingUpdateEvent was rather inefficient, where it needs to be highly performant, as it is run on every single entity in the game every tick.
    - Expensive checks are changed to be done after the inexpensive ones
    - Potion effects are moved to the Potion object's class so they are only applied on addition/removal (re-applying them every tick is not ideal)
- EntityUtils was part of why the above was inefficient
    - `EntityList.getKey` is not backed by a map, each lookup iterates the list; a cache has been added
    - wrapping an array in `Arrays.asList` creates needless GC overhead
    - If you'd prefer an object with `contains` I would suggest creating a HashSet in your config (re)load event

I would highly suggest you extensively test the freezing code, as you know best how it is supposed to work.